### PR TITLE
add confirmed to camp_enr + activity_enr / add age logic to activity

### DIFF
--- a/app/assets/stylesheets/components/_student_container.scss
+++ b/app/assets/stylesheets/components/_student_container.scss
@@ -8,8 +8,8 @@
 .header-info {
   background-color: black;
   color: $yellow;
-  // border-top-left-radius: 10px;
-  // border-top-right-radius: 10px;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
   text-align: center;
   padding: 0.5rem;
   font-size: 20px;

--- a/app/assets/stylesheets/components/_table.scss
+++ b/app/assets/stylesheets/components/_table.scss
@@ -231,6 +231,10 @@
   max-width: 8%;
 }
 
+.large-col {
+  max-width: 10%;
+}
+
 .equal-height-row {
   display: table-row; /* Force le comportement des cellules comme une ligne de tableau */
 }

--- a/app/controllers/managers/activity_enrollments_controller.rb
+++ b/app/controllers/managers/activity_enrollments_controller.rb
@@ -22,7 +22,7 @@ class Managers::ActivityEnrollmentsController < ApplicationController
       school_period = camp.school_period
 
       student_camp_courses = student.courses.joins(:activity).where("activities.camp_id = ?", camp.id)
-      if student_camp_courses.empty?
+      if student_camp_courses.empty? && camp_enrollment.paid == false
         camp_enrollment.destroy
       end
 

--- a/app/controllers/managers/annual_enrollments_controller.rb
+++ b/app/controllers/managers/annual_enrollments_controller.rb
@@ -21,8 +21,9 @@ class Managers::AnnualEnrollmentsController < ApplicationController
       annual_program_enrollment = @student.annual_program_enrollments.find_by(annual_program: annual_program)
       annual_program_enrollment.update(image_consent: image_consent)
 
-      @student.courses << activity.next_courses
       @student.activities << activity
+      @student.activity_enrollments.find_by(activity: activity).update(confirmed: true)
+      @student.courses << activity.next_courses
 
       start_year = annual_program.starts_at.year
       membership = @student.memberships.find_by(start_year: start_year)

--- a/app/controllers/managers/camps_controller.rb
+++ b/app/controllers/managers/camps_controller.rb
@@ -11,7 +11,6 @@ class Managers::CampsController < ApplicationController
   end
 
   def activities
-    # sleep 200
     @camp = Camp.find(params[:id])
     authorize([:managers, @camp])
     @activities = @camp.activities
@@ -35,7 +34,7 @@ class Managers::CampsController < ApplicationController
     authorize([:managers, camp])
     if camp.valid?
       # creer un produit stripe au nom du camp et de la periode scolaire et de l'academie
-      product = Stripe::Product.create(name: "#{camp.name} - #{camp.school_period.name} - #{camp.school_period.academy.name}")
+      product = Stripe::Product.create(name: "#{camp.name} - #{camp.school_period.name} - #{camp.school_period.year} - #{camp.school_period.academy.name}")
       price = Stripe::Price.create(product: product.id, unit_amount: camp.school_period.price * 100, currency: 'eur')
       camp.stripe_price_id = price.id
     end

--- a/app/controllers/managers/enrollments_controller.rb
+++ b/app/controllers/managers/enrollments_controller.rb
@@ -33,16 +33,21 @@ class Managers::EnrollmentsController < ApplicationController
         end
       end
 
+      # inscription au camp
       camp = Camp.find(params[:camp])
       @student.camps << camp unless @student.camps.include?(camp)
-
-
       image_consent = params[:image_consent]
       camp_enrollment = @student.camp_enrollments.find_by(camp: camp)
-      camp_enrollment.update(image_consent: image_consent)
+      camp_enrollment.update(confirmed: true, image_consent: image_consent)
 
-      @student.courses << activity.next_courses
+      # inscription à l'activité
       @student.activities << activity
+      @student.activity_enrollments.find_by(activity: activity).update(confirmed: true)
+
+      # inscription aux cours de l'activité
+      @student.courses << activity.next_courses
+
+      # gestion de la membership
       start_year = camp.starts_at.month >= 9 ? camp.starts_at.year : camp.starts_at.year - 1
       membership = @student.memberships.find_by(start_year: start_year)
       if membership.nil?

--- a/app/controllers/managers/import_annual_students_controller.rb
+++ b/app/controllers/managers/import_annual_students_controller.rb
@@ -58,6 +58,8 @@ class Managers::ImportAnnualStudentsController < ApplicationController
             end
           end
 
+          student.activity_enrollments.where(activity: annual_program.activities).update_all(confirmed: true)
+
           membership = student.memberships.find_by(start_year: start_year)
           if membership.nil?
             membership = Membership.create(student: student, amount: Membership::PRICE, start_year: start_year, academy: academy)
@@ -68,7 +70,7 @@ class Managers::ImportAnnualStudentsController < ApplicationController
             redirect_to managers_annual_program_path(annual_program) and return
           end
           if Membership::PAYMENT_METHODS.compact.include?(row['cotisation']) && membership.paid == false
-            membership.update(status: true, payment_method: row['cotisation'], payment_date: Date.current, receiver_id: current_user.id)
+            membership.update(paid: true, payment_method: row['cotisation'], payment_date: Date.current, receiver_id: current_user.id)
           end
         end
       end

--- a/app/javascript/controllers/activity_form_controller.js
+++ b/app/javascript/controllers/activity_form_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import TomSelect from "tom-select";
 
 export default class extends Controller {
-  static targets = ["startTime", "endTime", "mondayStartTime", "mondayEndTime", "category", "coach", "subform"]
+  static targets = ["startTime", "endTime", "mondayStartTime", "mondayEndTime", "category", "coach", "subform", "ageRanges"]
 
   static values = { academyId: Number }
 
@@ -50,4 +50,23 @@ export default class extends Controller {
     this.subformTarget.classList.remove("d-none");
     this.loadCoaches();
   }
+
+  addRanges() {
+    if (this.ageRangesTarget.innerHTML.trim() === "") {
+      this.ageRangesTarget.innerHTML = `
+        <div class="mb-3" data-age-fields>
+          <label for="activity_min_age" class="form-label">Age minimum</label>
+          <input type="number" name="activity[min_age]" id="activity_min_age" class="form-control activity-input" min="0" required="required">
+
+          <label for="activity_max_age" class="form-label mt-3">Age maximum</label>
+          <input type="number" name="activity[max_age]" id="activity_max_age" class="form-control activity-input" min="0" required="required">
+        </div>
+      `;
+    }
+  }
+
+  removeRanges() {
+    this.ageRangesTarget.innerHTML = "";
+  }
+    
 }

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -29,6 +29,11 @@ class Activity < ApplicationRecord
 
   validates :name, uniqueness: { scope: [:camp_id, :annual_program_id], message: "Une activité avec le même nom existe déjà" }
 
+  validates :age_restricted, inclusion: { in: [true, false] }
+  validates :min_age, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :max_age, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validate :age_range_valid?
+
   before_validation :normalize_name
 
   # before_save :starts_at_before_ends_at
@@ -133,6 +138,22 @@ class Activity < ApplicationRecord
   end
 
   private
+
+  def age_range_valid?
+    return unless age_restricted
+  
+    if min_age.nil?
+      errors.add(:min_age, "doit être renseigné")
+    end
+  
+    if max_age.nil?
+      errors.add(:max_age, "doit être renseigné")
+    end
+  
+    if min_age.present? && max_age.present? && min_age > max_age
+      errors.add(:base, "L'âge minimum ne peut pas être supérieur à l'âge maximum.")
+    end
+  end
 
   def normalize_name
     self.name = name.split.map(&:capitalize).join(' ')

--- a/app/models/camp_enrollment.rb
+++ b/app/models/camp_enrollment.rb
@@ -23,7 +23,7 @@ class CampEnrollment < ApplicationRecord
   # after_create :create_cart_item
   # after_create :create_school_period_enrollment
 
-  after_destroy :destroy_school_period_enrollment
+  # after_destroy :destroy_school_period_enrollment
 
   def camp_starts_at
     camp.starts_at
@@ -76,7 +76,7 @@ class CampEnrollment < ApplicationRecord
   #   end
   # end
 
-  def destroyy_school_period_enrollment
+  def destroy_school_period_enrollment
     camp_enrollments = student.camp_enrollments.where(camp: school_period.camps)
     if camp_enrollments.empty?
       student.school_period_enrollments.find_by(school_period: school_period).destroy

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -16,6 +16,10 @@ class Course < ApplicationRecord
   # after_update_commit -> { broadcast_replace_to "today_courses", partial: "managers/academies/today_course", locals: { course: self, academy: academy }, target: self }
   # after_update_commit -> { broadcast_remove_to "today_courses", target: "old_course_#{id}" }
 
+  validates :starts_at, presence: true
+  validates :ends_at, presence: true
+  validate :starts_at_before_ends_at
+  
   def academy
     return camp.academy if camp
     return annual_program.academy if annual_program

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,6 +116,10 @@ class User < ApplicationRecord
     "#{last_name.upcase} #{first_name.capitalize}"
   end
 
+  def full_name_short
+    "#{first_name.capitalize} #{last_name.first.capitalize}."
+  end
+
   def next_activities
     activities.joins(:camp).where('camps.ends_at > ?', Time.current).order('camps.starts_at')
   end

--- a/app/views/managers/activities/destroy.turbo_stream.erb
+++ b/app/views/managers/activities/destroy.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.replace "flash-messages" do %>
+  <%= render "shared/flashes" %>
+<% end %>
+
+<%= turbo_stream.remove "activity-#{@activity.id}" %>

--- a/app/views/managers/activities/new.html.erb
+++ b/app/views/managers/activities/new.html.erb
@@ -12,7 +12,26 @@
   <div class="form-container form-min-width" data-controller="activity-form" data-activity-form-academy-id-value="<%= @academy.id  %>">
     <%= simple_form_for @activity, url: managers_activities_path(camp: @camp), method: :post do |f| %>
       <%= f.input :name, label: "Nom", input_html: { class: "activity-input" } %>
+      <%= f.hidden_field :age_restricted, value: false if @academy.name == "Éole" %>
+
+      <% unless @academy.name == "Éole" %>
+        <div class="mb-3">
+          <%= f.label :age_restricted, "Activité concernée par une tranche d'âge ?", class: "form-label" %>
+          <div>
+            <%= f.radio_button :age_restricted, true, class: "activity-input", checked: @activity.age_restricted == true, required: true, data: { action: 'change->activity-form#addRanges' } %>
+            <%= f.label :age_restricted_true, "Oui" %>
+
+            <%= f.radio_button :age_restricted, false, class: "activity-input", checked: @activity.age_restricted == false, required: true, data: { action: 'change->activity-form#removeRanges' } %>
+            <%= f.label :age_restricted_false, "Non" %>
+          </div>
+        </div>
+      <% end %>
+
+      <div data-activity-form-target="ageRanges">
+
+      </div>
       <%= f.input :category_id, as: :select, collection: Category.all.order(:name), label: "Categorie", label_method: :name, value_method: :id, input_html: { data: { activity_form_target: "category", action: 'change->activity-form#onCategoryChange' }, class: "activity-input" } %>
+
       <div class="d-none" data-activity-form-target="subform">
         <%= f.input :coach_id, as: :select, label: "Coach Principal", collection: User.all, label_method: :full_name, value_method: :id, input_html: { class: "tom-select", data: { controller: "tom-select", activity_form_target: "coach" } } %>
         <%= f.input :coach_ids, as: :select, label: "Autres coachs", collection: User.all, label_method: :full_name, value_method: :id, input_html: { class: "tom-select", multiple: true, data: { controller: "tom-select", activity_form_target: "coach" } } %>

--- a/app/views/managers/camp_enrollments/destroy.turbo_stream.erb
+++ b/app/views/managers/camp_enrollments/destroy.turbo_stream.erb
@@ -2,4 +2,6 @@
   <%= render "shared/flashes" %>
 <% end %>
 
-<%= turbo_stream.remove "camp-enrollment-#{@camp_enrollment.id}" %>
+<% unless @camp_enrollment.paid %>
+  <%= turbo_stream.remove "camp-enrollment-#{@camp_enrollment.id}" %>
+<% end %>

--- a/app/views/managers/camps/_activities.html.erb
+++ b/app/views/managers/camps/_activities.html.erb
@@ -1,49 +1,62 @@
 <%= turbo_frame_tag "selected_content" do %>
-  <!--<div class="yellow-title">LES ACTIVITÉS</div>-->
-  <div class="container">
+  <div class="container container-big" data-controller="clickable-table">
     <% if @activities.any? %>
-      <table class="table table-striped table-responsive table-center form-container" data-controller="clickable-table">
-        <thead>
-          <tr>
-            <th>Activité</th>
-            <th>Catégorie</th>
-            <th>Lieu</th>
-            <th>Coach Référent</th>
-            <th>Nombre d'élèves inscrits</th>
-            <% if current_user.manager? %>
-              <th>Supprimer</th>
-            <% end %>
-          </tr>
-        </thead>
-        <tbody>
-          <% @activities.sort.each do |activity| %>
-            <tr class="clickable-tr" data-clickable-table-target="clickable" data-url="<%= managers_activity_path(activity) %>">
-              <td><%= activity.name %></td>
-              <td><%= activity.category.name %></td>
-              <td><%= activity.location.name %></td>
-              <td><%= activity.coach.try(:full_name) || "" %></td>
-              <td><%= activity.students.count %></td>
-              <% if current_user.manager? %>
-                <% if activity.can_delete? %>
-                  <td>
-                    <%= link_to managers_activity_path(activity), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Êtes-vous sûr de vouloir supprimer cette activité ?" } do %>
-                      <i class="fas fa-trash trash"></i>
-                    <% end %>
-                  </td>
-                <% else %>
-                  <td></td>
-                <% end %>
-              <% end %>
-            </tr>
+      <div class="card-row-container">
+        <div class="row pb-2 pt-2 header-row align-items-center">
+          <div class="col flexy-row">Activité</div>
+          <div class="col large-col flexy-row">Catégorie</div>
+          <div class="col flexy-row">Lieu</div>
+          <div class="col large-col flexy-row">Coach Référent</div>
+          <div class="col small-col flexy-row">Age min</div>
+          <div class="col small-col flexy-row">Age max</div>
+          <div class="col small-col flexy-row">Inscrits</div>
+          <% if current_user.manager? %>
+            <div class="col small-col flexy-row">Supp</div>
           <% end %>
-        </tbody>
-      </table>
+        </div>
+        <% @activities.sort_by(&:name).each do |activity| %>
+          <div id="activity-<%= activity.id %>" class="row card-row card-row-no-transform clickable-tr" data-clickable-table-target="clickable" data-url="<%= managers_activity_path(activity) %>">
+            <div class="col flexy-row">
+              <span class="ellipsis"><%= activity.name %></span>
+            </div>
+            <div class="col large-col flexy-row">
+              <span class="ellipsis"><%= activity.category.name %></span>
+            </div>
+            <div class="col flexy-row">
+              <span class="ellipsis"><%= activity.location.name %></span>
+            </div>
+            <div class="col large-col flexy-row">
+              <span class="ellipsis"><%= activity.coach.try(:full_name_short) || "" %></span>
+            </div>
+            <div class="col small-col flexy-row">
+              <span class="ellipsis"><%= activity.age_restricted ? "#{activity.min_age} ans" : "" %></span>
+            </div>
+            <div class="col small-col flexy-row">
+              <span class="ellipsis"><%= activity.age_restricted ? "#{activity.max_age} ans" : "" %></span>
+            </div>
+            <div class="col small-col flexy-row">
+              <span class="ellipsis"><%= activity.students.count %></span>
+            </div>
+            <% if current_user.manager? %>
+              <% if activity.can_delete? %>
+                <div class="col small-col flexy-row">
+                  <%= link_to managers_activity_path(activity), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Êtes-vous sûr de vouloir supprimer cette activité ?" } do %>
+                    <i class="fas fa-trash trash"></i>
+                  <% end %>
+                </div>
+              <% else %>
+                <div class="col small-col flexy-row"></div>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     <% else %>
       <div class="flexy mb-4 mt-4">Aucune activité pour le moment.</div>
     <% end %>
     <% if current_user.manager? %>
       <div class="flexy">
-        <%= link_to new_managers_activity_path(camp: @camp), data: { turbo_frame: "_top" }, class: "btn-add-student btn-large btn-flex mt-1" do %>
+        <%= link_to new_managers_activity_path(camp: @camp), data: { turbo_frame: "_top" }, class: "btn-add-student btn-large btn-flex mt-3" do %>
           <i class="fa-solid fa-square-plus fa-square-bigger"></i>AJOUTER UNE ACTIVITÉ<i class="fa-solid fa-square-plus fa-square-bigger"></i>
         <% end %>
       </div>

--- a/app/views/managers/camps/_student_list.html.erb
+++ b/app/views/managers/camps/_student_list.html.erb
@@ -31,7 +31,7 @@
             <span class="ellipsis">Gratuit</i></span>
           <% end %>
         </div>
-      <% elsif camp_enrollment&.present %>
+      <% else %>
         <div class="col flexy-row small-col">
           <% if camp_enrollment.paid %>
             <i class="fa-solid fa-circle-check text-success fa-small"></i>
@@ -39,14 +39,14 @@
             <i class="fa-solid fa-circle-xmark fa-pink fa-big fa-small"></i>
           <% end %>
         </div>
-      <% elsif !camp_enrollment&.present && camp_enrollment.paid %>
-        <div class="col flexy-row small-col">
+      <%# elsif !camp_enrollment&.present && camp_enrollment.paid %>
+<!--        <div class="col flexy-row small-col">
           <i class="fa-solid fa-circle-check text-success fa-small"></i>
         </div>
-      <% elsif !camp_enrollment&.present %>
-        <div class="col flexy-row small-col">
+      <%# elsif !camp_enrollment&.present %>-->
+<!--        <div class="col flexy-row small-col">
           <span class="ellipsis">Absent</span>
-        </div>
+        </div>-->
       <% end %>
     <% end %>
 

--- a/app/views/managers/camps/show.html.erb
+++ b/app/views/managers/camps/show.html.erb
@@ -36,7 +36,7 @@
   <% end %>
 </div>
 
-<% if false %>
+<% if @camp.can_import? %>
   <div class="yellow-title mb-3 mt-3">IMPORT CSV</div>
   <div class="flexy" data-controller="import-csv">
     <div class="loader d-none" data-import-csv-target="spinner"></div>

--- a/app/views/managers/school_periods/index.html.erb
+++ b/app/views/managers/school_periods/index.html.erb
@@ -72,6 +72,7 @@
         <th>Académie</th>
         <th>Stage</th>
         <th>Année</th>
+        <th>Prix / semaine</th>
         <th>Élèves inscrits</th>
         <th>Supprimer</th>
       </tr>
@@ -82,6 +83,7 @@
         <td><%= period.academy.name %></td>
         <td><%= period.name %></td>
         <td><%= period.year %></td>
+        <td><%= period.paid ? "#{period.price}€" : "Gratuit" %></td>
         <td><%= period.students_count %></td>
         <td>
         <% if period.can_import? %>

--- a/app/views/managers/school_periods/show.html.erb
+++ b/app/views/managers/school_periods/show.html.erb
@@ -19,9 +19,12 @@
           <th>Académie</th>
           <th>Stage</th>
           <th>Semaine</th>
+          <th>Prix</th>
           <th>Début</th>
           <th>Fin</th>
+          <th>Capacité</th>
           <th>Élèves inscrits</th>
+          <th>Places dispo</th>
           <% if current_user.manager? %>
             <th>Supprimer</th>
           <% end %>
@@ -33,9 +36,12 @@
           <td class="align-middle"><%= @school_period.academy.name %></td>
           <td class="align-middle"><%= @school_period.name %></td>
           <td class="align-middle"><%= camp.name %></td>
+          <td class="align-middle"><%= @school_period.paid ? "#{@school_period.price}€" : "Gratuit" %></td>
           <td class="align-middle"><%= l(camp.starts_at, format: :date) %></td>
           <td class="align-middle"><%= l(camp.ends_at, format: :date) %></td>
+          <td class="align-middle"><%= camp.capacity %></td>
           <td class="align-middle"><%= camp.students_count %></td>
+          <td class="align-middle"><%= camp.capacity - camp.students_count %></td>
           <% if current_user.manager? %>
             <% if camp.can_import? &&  %>
               <td class="align-middle">
@@ -68,10 +74,8 @@
       <%= form.date_field :starts_at, class: "form-control", required: true %>
       <%= form.label :ends_at, "Date de fin :" %>
       <%= form.date_field :ends_at, class: "form-control", required: true %>
-      <%= form.label :capacity, "Capacité maximale d'étudiants:" %>
+      <%= form.label :capacity, "Nombre de places :" %>
       <%= form.number_field :capacity, class: "form-control", required: true %>
-      <%= form.label :waitlist_capacity, "Capacité de la liste d'attente:" %>
-      <%= form.number_field :waitlist_capacity, class: "form-control", required: true %>
 
       <div class="flex-btn mt-3">
         <%= form.submit "Valider", class: "btn-add-student btn-add-student-small" %>

--- a/db/migrate/20250209085730_add_confirmed_to_camp_enrollments_and_activity_enrollments.rb
+++ b/db/migrate/20250209085730_add_confirmed_to_camp_enrollments_and_activity_enrollments.rb
@@ -1,0 +1,6 @@
+class AddConfirmedToCampEnrollmentsAndActivityEnrollments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :camp_enrollments, :confirmed, :boolean, default: false
+    add_column :activity_enrollments, :confirmed, :boolean, default: false
+  end
+end

--- a/db/migrate/20250209102041_remove_default_capacity_value_to_camps.rb
+++ b/db/migrate/20250209102041_remove_default_capacity_value_to_camps.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultCapacityValueToCamps < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :camps, :capacity, nil
+  end
+end

--- a/db/migrate/20250209104842_add_age_restriction_to_activities.rb
+++ b/db/migrate/20250209104842_add_age_restriction_to_activities.rb
@@ -1,0 +1,20 @@
+class AddAgeRestrictionToActivities < ActiveRecord::Migration[7.0]
+  def up
+    add_column :activities, :age_restricted, :boolean, default: false
+    add_column :activities, :min_age, :integer
+    add_column :activities, :max_age, :integer
+
+    # Mise à jour des enregistrements existants
+    Activity.update_all(age_restricted: false)
+
+    # Suppression du défaut et ajout de la contrainte null: false pour `age_restricted`
+    change_column_default :activities, :age_restricted, nil
+    change_column_null :activities, :age_restricted, false
+  end
+
+  def down
+    remove_column :activities, :age_restricted
+    remove_column :activities, :min_age
+    remove_column :activities, :max_age
+  end
+end

--- a/db/migrate/20250209141119_enable_unaccent_extension.rb
+++ b/db/migrate/20250209141119_enable_unaccent_extension.rb
@@ -1,0 +1,5 @@
+class EnableUnaccentExtension < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension 'unaccent'
+  end
+end

--- a/db/migrate/20250209142359_remove_max_capacity_to_activities.rb
+++ b/db/migrate/20250209142359_remove_max_capacity_to_activities.rb
@@ -1,0 +1,6 @@
+class RemoveMaxCapacityToActivities < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :activities, :max_capacity, :integer
+    remove_column :activities, :min_capacity, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_20_033700) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_09_142359) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "unaccent"
 
   create_table "academies", force: :cascade do |t|
     t.string "name"
@@ -68,13 +69,14 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_20_033700) do
     t.bigint "camp_id"
     t.bigint "category_id", null: false
     t.bigint "coach_id"
-    t.integer "min_capacity"
-    t.integer "max_capacity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "location_id", null: false
     t.bigint "annual_program_id"
     t.boolean "annual", default: false
+    t.boolean "age_restricted", null: false
+    t.integer "min_age"
+    t.integer "max_age"
     t.index ["annual_program_id"], name: "index_activities_on_annual_program_id"
     t.index ["camp_id"], name: "index_activities_on_camp_id"
     t.index ["category_id"], name: "index_activities_on_category_id"
@@ -97,6 +99,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_20_033700) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "present", default: false
+    t.boolean "confirmed", default: false
     t.index ["activity_id"], name: "index_activity_enrollments_on_activity_id"
     t.index ["student_id"], name: "index_activity_enrollments_on_student_id"
   end
@@ -194,6 +197,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_20_033700) do
     t.bigint "receiver_id"
     t.string "stripe_price_id"
     t.boolean "on_waitlist", default: false
+    t.boolean "confirmed", default: false
     t.index ["camp_id"], name: "index_camp_enrollments_on_camp_id"
     t.index ["receiver_id"], name: "index_camp_enrollments_on_receiver_id"
     t.index ["student_id"], name: "index_camp_enrollments_on_student_id"
@@ -231,7 +235,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_20_033700) do
     t.datetime "updated_at", null: false
     t.boolean "new", default: true
     t.string "stripe_price_id"
-    t.integer "capacity", default: 20
+    t.integer "capacity"
     t.integer "waitlist_capacity", default: 5
     t.index ["school_period_id"], name: "index_camps_on_school_period_id"
   end


### PR DESCRIPTION
- Ajout de la colonne confirmed (default false) à camp_enrollment et activity_enrollment
- Changement du code existant en conséquence
- Suppression de la default_value de capacity pour le model camp
- Ajout de age_restricted (boolean) au model activity ainsi que min_age et max_age
- Modification du formulaire de création d'activity pour prendre en compte ces nouveaux attributs
- Modification des vues managers pour ces critères
- Amélioration du l'UX pour suppression camp
- Ajout d'une migration pour remettre l'extension psql unaccent
- Suppression des colonnes max_capacity et min_capacity de activity (ancien code inutile)
- Rétablissement des border radius pour .header-info